### PR TITLE
🚧 Plugin deprecation 🚧

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+> ## 🚧 This Plugin Is Deprecated 🚧
+
+> This project is deprecated in favor of `process.env.NODE_ENV`. 
+
 # environment-brunch
 
 Replaces a defined token with the current environment in your js/ts files in Brunch.


### PR DESCRIPTION
We at Brunch team decided that it would be better to deprecate this plugin in favor of `process.env.NODE_ENV`. Please, merge this pull request.

**Important:** Do **_not_** deprecate this plugin on NPM. Let our user not to see all these useless deprecation warnings.

Thank you for understanding.